### PR TITLE
Revision 0.11.1

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,6 +7,7 @@
     "serve": "deno run -A tasks.ts serve",
     "report": "deno run -A tasks.ts report",
     "metrics": "deno run -A  tasks.ts metrics",
+    "publish": "deno run -A  tasks.ts publish",
     "build:dual": "deno run -A tasks.ts build:dual",
     "build:esm": "deno run -A tasks.ts build:esm"
   },

--- a/src/serve/debounce.ts
+++ b/src/serve/debounce.ts
@@ -1,0 +1,84 @@
+/*--------------------------------------------------------------------------
+
+Tasksmith
+
+The MIT License (MIT)
+
+Copyright (c) 2025 Haydn Paterson (sinclair)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+export type DebounceCallback = () => Promise<unknown> | unknown
+export type ErrorCallback = (error: Error) => void
+
+export interface DebounceOptions {
+  /** The debounce frequency. Default is 1000 */
+  millisecond?: number
+  /** Dispatch the last operation at end of debounce window. Default is false */
+  dispatchLast?: boolean
+}
+export class Debounce {
+  readonly #millisecond: number
+  readonly #deferred: boolean
+  #callback: DebounceCallback | null
+  #waiting: boolean
+  constructor(options: DebounceOptions) {
+    this.#millisecond = options.millisecond ?? 1000
+    this.#deferred = options.dispatchLast ?? false
+    this.#callback = null
+    this.#waiting = false
+  }
+  public run(callback: DebounceCallback, errorCallback: ErrorCallback = () => {}) {
+    if (this.#deferred) {
+      this.#runDeferred(callback, errorCallback)
+    } else {
+      this.#runDefault(callback, errorCallback)
+    }
+  }
+  async #runDeferred(callback: DebounceCallback, errorCallback: ErrorCallback) {
+    if (this.#waiting) {
+      this.#callback = callback
+      return
+    }
+    this.#waiting = true
+    this.#execute(callback).catch(errorCallback)
+    await this.#delay()
+    while (this.#callback !== null) {
+      this.#execute(this.#callback).catch(errorCallback)
+      this.#callback = null
+      await this.#delay()
+    }
+    this.#waiting = false
+  }
+  async #runDefault(callback: DebounceCallback, errorCallback: ErrorCallback) {
+    if (this.#waiting) return
+    this.#waiting = true
+    this.#execute(callback).catch(errorCallback)
+    await this.#delay()
+    this.#waiting = false
+  }
+  async #execute(callback: DebounceCallback) {
+    await callback()
+  }
+  #delay() {
+    return new Promise((resolve) => setTimeout(resolve, this.#millisecond))
+  }
+}

--- a/src/serve/socket.ts
+++ b/src/serve/socket.ts
@@ -26,6 +26,10 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { Debounce } from './debounce.ts'
+
+const debounce = new Debounce({ dispatchLast: true, millisecond: 200 })
+
 // ------------------------------------------------------------------
 // Watch
 // ------------------------------------------------------------------
@@ -33,7 +37,7 @@ export async function StartWatch(directory: string) {
   const watcher = Deno.watchFs(directory)
   for await (const event of watcher) {
     if (['create', 'modify', 'remove'].includes(event.kind)) {
-      BroadcastReload()
+      debounce.run(() => BroadcastReload())
     }
   }
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -1,5 +1,7 @@
 import { Task } from './src/index.ts'
 
+const Version = '0.11.1'
+
 // ------------------------------------------------------------------
 // Clean
 // ------------------------------------------------------------------
@@ -77,4 +79,10 @@ Task.run('test', () => Task.test.run(['test/subset0', 'test/subset1']))
 // Report
 // ------------------------------------------------------------------
 Task.run('report', () => Task.test.report(['test/subset0', 'test/subset1']))
-
+// ------------------------------------------------------------------
+// Publish
+// ------------------------------------------------------------------
+Task.run('publish', async () => {
+  await Task.shell(`git tag ${Version}`)
+  await Task.shell(`git push origin ${Version}`)
+})


### PR DESCRIPTION
This PR adds a debounce when sending page reload signals. This update prevents throttling the browser with reload signals when many files are updated in the serve directory (for example, when copying large numbers of assets)