### PR TITLE
feat: add require-esm support for node

### DIFF
--- a/src/build/esm/build-package-json.ts
+++ b/src/build/esm/build-package-json.ts
@@ -46,14 +46,15 @@ export type PackageEntryAndExports = {
 }>
 }
 async function buildPackageExports(baseUri: string): Promise<PackageEntryAndExports> {
-  const exports: Record<string, { import: string }> = {}
+  const exports: Record<string, { import: string, default: string }> = {}
   for (const filePath of await folder(baseUri).indexList()) {
     const isRoot = filePath === 'index.ts';
     const submoduleSection = isRoot ? '.' : `./${filePath.replace(/\/index\.ts$/, '')}`
     const submoduleBase = isRoot ? '' : `${filePath.replace(/\/index\.ts$/, '')}`
     const esmDir = submoduleBase ? `./${Folder}/${submoduleBase}` : `./${Folder}`
     exports[submoduleSection] = {
-      import: `${esmDir}/index.mjs`
+      import: `${esmDir}/index.mjs`,
+      default: `${esmDir}/index.mjs`
     }
   }
   return {


### PR DESCRIPTION
Hey @sinclairzx81!

For some context, I was experimenting with bumping `typebox` to v1 over at [fastify-type-provider-typebox](https://github.com/fastify/fastify-type-provider-typebox/pull/241) with little success

I saw that `typebox@1` is ESM-only - normally, it should no longer be a problem in recent node versions where we have require(ESM) support, but the problem is node can't find the correct exports field when `typebox` is being imported from a CJS module

This PR simply adds the `default` exports field so that node can find the module