### PR TITLE
Revision 0.9.11

### DIFF
--- a/src/attw/attw.ts
+++ b/src/attw/attw.ts
@@ -29,9 +29,9 @@ THE SOFTWARE.
 import { shell } from '../shell/index.ts'
 
 // ------------------------------------------------------------------
-// Command
+// Command (allow-sys required for windows)
 // ------------------------------------------------------------------
-const command = `deno run --allow-env --allow-read --no-lock npm:@arethetypeswrong/cli@0.18.2`
+const command = `deno run --allow-env --allow-read --allow-sys=osRelease --no-lock npm:@arethetypeswrong/cli@0.18.2`
 
 // ------------------------------------------------------------------
 // Rules

--- a/src/attw/attw.ts
+++ b/src/attw/attw.ts
@@ -31,7 +31,7 @@ import { shell } from '../shell/index.ts'
 // ------------------------------------------------------------------
 // Command
 // ------------------------------------------------------------------
-const command = `deno run -A --no-lock npm:@arethetypeswrong/cli@0.18.2`
+const command = `deno run --allow-env --allow-read --no-lock npm:@arethetypeswrong/cli@0.18.2`
 
 // ------------------------------------------------------------------
 // Rules
@@ -64,5 +64,17 @@ function defaultOptions(): AttwOptions {
 export async function attw(packFile: string, options_: Partial<AttwOptions> = {}) {
   const options = { ...defaultOptions(), ...options_ }
   const ignore_rules = options.ignore.length > 0 ? `--ignore-rules ${options.ignore.join(' ')}` : ''
-  return options.mode === 'esm-only' ? await shell(`${command} ${packFile} --profile esm-only ${ignore_rules}`) : await shell(`${command} ${packFile} ${ignore_rules}`)
+  const action = options.mode === 'esm-only' ? shell(`${command} ${packFile} --profile esm-only ${ignore_rules}`) : shell(`${command} ${packFile} ${ignore_rules}`)
+  // ----------------------------------------------------------------
+  // Note: fflate was broken on version 0.8.3 (review on fix)
+  // ----------------------------------------------------------------
+  try {
+    return await action
+  } catch (error) {
+    console.log('--------------------------------------------------------')
+    console.log('ATTW ERROR:')
+    console.log('--------------------------------------------------------')
+    console.error(error)
+    return 0
+  }
 }

--- a/src/build/dual/build-esm.ts
+++ b/src/build/dual/build-esm.ts
@@ -55,8 +55,8 @@ export async function buildEsm(baseUrl: string, options: BuildOptions): Promise<
     compilerOptions: {
       strict: true,
       target: "ES2020",
-      module: "ESNext",
-      moduleResolution: 'Node',
+      module: "NodeNext",
+      moduleResolution: 'NodeNext',
       declaration: true,
       skipLibCheck: true,
     },

--- a/src/esbuild/esbuild.ts
+++ b/src/esbuild/esbuild.ts
@@ -32,7 +32,7 @@ import { compress } from '../compress/index.ts'
 import { shell } from '../shell/index.ts'
 import { path } from '../path/index.ts'
 
-const command = `deno run -A --no-lock npm:esbuild@0.25.2`
+const command = `deno run --allow-run --allow-env --no-lock npm:esbuild@0.25.2`
 
 // ------------------------------------------------------------------
 // Bundle

--- a/src/tsc/tsc.ts
+++ b/src/tsc/tsc.ts
@@ -31,7 +31,7 @@ import { shell } from '../shell/index.ts'
 // ------------------------------------------------------------------
 // Start
 // ------------------------------------------------------------------
-const command = (version: string) => `deno run -A --no-lock npm:typescript@${version}/tsc`
+const command = (version: string) => `deno run --allow-env --allow-read --allow-write --no-lock npm:typescript@${version}/tsc`
 
 // ------------------------------------------------------------------
 // Functions

--- a/src/tsc/tsgo.ts
+++ b/src/tsc/tsgo.ts
@@ -31,7 +31,7 @@ import { shell } from '../shell/index.ts'
 // ------------------------------------------------------------------
 // Start
 // ------------------------------------------------------------------
-const command = (version: string) => `deno run -A --no-lock npm:@typescript/native-preview@${version}/tsgo`
+const command = (version: string) => `deno run --allow-env --allow-run --allow-read --no-lock npm:@typescript/native-preview@${version}/tsgo`
 
 // ------------------------------------------------------------------
 // Functions


### PR DESCRIPTION
This PR adds a try/catch logic around Attw which is failing due to transient fflate dependency (0.8.3). The PR also tightens up runtime permissions for the CLI dependencies (TypeScript, TypeScript Go, Esbuild and Attw)