### PR TITLE
Revision 0.9.15

### DIFF
--- a/src/folder/index-list.ts
+++ b/src/folder/index-list.ts
@@ -26,12 +26,18 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-function sortList(items: string[]): string[] {
+// ------------------------------------------------------------------
+// IndexListSort
+// ------------------------------------------------------------------
+function indexListSort(items: string[]): string[] {
   return items.sort((a, b) => {
     const [depthA, depthB] = [a.split('/').length, b.split('/').length]
     return (depthA !== depthB) ? depthB - depthA : a.localeCompare(b)
   })
 }
+// ------------------------------------------------------------------
+// IndexList
+// ------------------------------------------------------------------
 /** Returns an index list of `index.ts` files from this folder (build process) */
 export async function indexList(directoryPath: string, depth: number = 1, currentDepth: number = 0, root: string = directoryPath): Promise<string[]> {
   const indexFile = `${directoryPath}/index.ts`
@@ -52,5 +58,5 @@ export async function indexList(directoryPath: string, depth: number = 1, curren
   }
   const output = directoryPath === root ? 'index.ts' : indexFile.slice(root.length + 1)
   result.push(output)
-  return sortList(result)
+  return indexListSort(result)
 }

--- a/src/folder/index-list.ts
+++ b/src/folder/index-list.ts
@@ -26,6 +26,12 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+function sortList(items: string[]): string[] {
+  return items.sort((a, b) => {
+    const [depthA, depthB] = [a.split('/').length, b.split('/').length]
+    return (depthA !== depthB) ? depthB - depthA : a.localeCompare(b)
+  })
+}
 /** Returns an index list of `index.ts` files from this folder (build process) */
 export async function indexList(directoryPath: string, depth: number = 1, currentDepth: number = 0, root: string = directoryPath): Promise<string[]> {
   const indexFile = `${directoryPath}/index.ts`
@@ -46,5 +52,5 @@ export async function indexList(directoryPath: string, depth: number = 1, curren
   }
   const output = directoryPath === root ? 'index.ts' : indexFile.slice(root.length + 1)
   result.push(output)
-  return result
+  return sortList(result)
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -1,6 +1,6 @@
 import { Task } from './src/index.ts'
 
-const Version = '0.9.14'
+const Version = '0.9.15'
 
 // ------------------------------------------------------------------
 // Clean


### PR DESCRIPTION
This PR ensures `package.json` exports are sorted uniformly. It has been noted that CI environments and Deno do not guarantee a alphabetical sort ordering on directory enumeration. This PR handles ordering explicitly.